### PR TITLE
chore: Smoothened first time use of nx commands

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,6 @@ jobs:
           sudo apt install openmpi-bin libopenmpi-dev
           # Install `libhdf5` for `morphio`
           sudo apt install libhdf5-dev
-          # Install `libgsl-dev` for conductance-based NEST models 
-          sudo apt install libgsl-dev
 
       - name: Install nodejs
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,10 +27,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
-      - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        id: setSHAs
-        uses: nrwl/nx-set-shas@v4
-
       - run: |
           # There is flake on `npx cross-env`, pre-install it a couple times to prevent that.
           npx -y cross-env echo "" > /dev/null

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -28,9 +28,6 @@ jobs:
           \. "$HOME/.nvm/nvm.sh"
           nvm install --lts
 
-      - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@v4
-
       - name: Get affected projects
         id: get-affected
         run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,7 +11,7 @@ jobs:
       - name: PR Conventional Commit Validation
         uses:  ytanikin/PRConventionalCommits@1.3.0
         with:
-          task_types: '["feat","fix","docs","test","ci","refactor","perf","revert"]'
+          task_types: '["feat","fix","chore","docs","test","ci","refactor","perf","revert"]'
 
   get-modified:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # The Brain Scaffold Builder
 
 ![Build Status](https://github.com/dbbs-lab/bsb/actions/workflows/main.yml/badge.svg)
+[![codecov](https://codecov.io/gh/dbbs-lab/bsb/graph/badge.svg?token=9b20cUHwzX)](https://codecov.io/gh/dbbs-lab/bsb)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
 Developed by the Department of Brain and Behavioral Sciences at the University of Pavia, the Brain Scaffold Builder (

--- a/libs/arborize/project.json
+++ b/libs/arborize/project.json
@@ -43,7 +43,7 @@
       "outputs": ["{projectRoot}/docs/_build/html"],
       "options": {
         "commands": [
-          "npx rimraf _build/html/",
+          "npx -y rimraf _build/html/",
           "uv run sphinx-build -nW -b html . _build/html"
         ],
         "parallel": false,
@@ -72,7 +72,7 @@
       "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
         "commands": [
-          "npx rimraf .coverage*",
+          "npx -y rimraf .coverage*",
           "uv run coverage run -p -m unittest discover -v -s ./tests",
           "mpiexec -n 2 uv run coverage run -p -m unittest discover -v -s ./tests",
           "uv run coverage combine",

--- a/libs/nmodl-glia/project.json
+++ b/libs/nmodl-glia/project.json
@@ -42,7 +42,7 @@
       "outputs": ["{projectRoot}/docs/_build/html"],
       "options": {
         "commands": [
-          "npx rimraf _build/html/",
+          "npx -y rimraf _build/html/",
           "uv run sphinx-build -nW -b html . _build/html"
         ],
         "parallel": false,
@@ -71,7 +71,7 @@
       "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
         "commands": [
-          "npx rimraf .coverage*",
+          "npx -y rimraf .coverage*",
           "uv run coverage run --source glia -p -m unittest discover -v -s ./tests",
           "mpiexec -n 2 uv run coverage run --source glia -p -m unittest discover -v -s ./tests",
           "uv run coverage combine",

--- a/libs/nrn-patch/project.json
+++ b/libs/nrn-patch/project.json
@@ -42,7 +42,7 @@
       "outputs": ["{projectRoot}/docs/_build/html"],
       "options": {
         "commands": [
-          "npx rimraf _build/html/",
+          "npx -y rimraf _build/html/",
           "uv run sphinx-build -nW -b html . _build/html"
         ],
         "parallel": false,
@@ -71,7 +71,7 @@
       "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
         "commands": [
-          "npx rimraf .coverage*",
+          "npx -y rimraf .coverage*",
           "uv run coverage run --source patch -p -m unittest discover -v -s ./tests",
           "mpiexec -n 2 uv run coverage run --source patch -p -m unittest discover -v -s ./tests",
           "uv run coverage combine",

--- a/packages/bsb-arbor/project.json
+++ b/packages/bsb-arbor/project.json
@@ -58,7 +58,7 @@
       "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
         "commands": [
-          "npx rimraf .coverage*",
+          "npx -y rimraf .coverage*",
           "uv run coverage run -p -m unittest discover -v -s ./tests",
           "mpiexec -n 2 uv run coverage run -p -m unittest discover -v -s ./tests",
           "uv run coverage combine",
@@ -75,7 +75,7 @@
       "outputs": ["{projectRoot}/docs/_build/iso-html"],
       "options": {
         "commands": [
-          "npx rimraf _build/iso-html/",
+          "npx -y rimraf _build/iso-html/",
           "uv run sphinx-build -b html . _build/iso-html"
         ],
         "parallel": false,
@@ -89,8 +89,8 @@
       "outputs": ["{projectRoot}/docs/_build/html"],
       "options": {
         "commands": [
-          "npx rimraf _build/html/",
-          "npx cross-env BSB_LOCAL_INTERSPHINX_ONLY=true uv run sphinx-build -nW -b html . _build/html"
+          "npx -y rimraf _build/html/",
+          "npx -y cross-env BSB_LOCAL_INTERSPHINX_ONLY=true uv run sphinx-build -nW -b html . _build/html"
         ],
         "parallel": false,
         "cwd": "{projectRoot}/docs/"

--- a/packages/bsb-core/project.json
+++ b/packages/bsb-core/project.json
@@ -58,7 +58,7 @@
       "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
         "commands": [
-          "npx rimraf .coverage*",
+          "npx -y rimraf .coverage*",
           "uv run coverage run -p -m unittest discover -v -s ./tests",
           "mpiexec -n 2 uv run coverage run -p -m unittest discover -v -s ./tests",
           "uv run coverage combine",
@@ -75,7 +75,7 @@
       "outputs": ["{projectRoot}/docs/_build/iso-html"],
       "options": {
         "commands": [
-          "npx rimraf _build/iso-html/",
+          "npx -y rimraf _build/iso-html/",
           "uv run sphinx-build -v -b html . _build/iso-html"
         ],
         "parallel": false,
@@ -89,8 +89,8 @@
       "outputs": ["{projectRoot}/docs/_build/html"],
       "options": {
         "commands": [
-          "npx rimraf _build/html/",
-          "npx cross-env BSB_LOCAL_INTERSPHINX_ONLY=true uv run sphinx-build -nW -b html . _build/html"
+          "npx -y rimraf _build/html/",
+          "npx -y cross-env BSB_LOCAL_INTERSPHINX_ONLY=true uv run sphinx-build -nW -b html . _build/html"
         ],
         "parallel": false,
         "cwd": "{projectRoot}/docs/"

--- a/packages/bsb-hdf5/project.json
+++ b/packages/bsb-hdf5/project.json
@@ -58,7 +58,7 @@
       "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
         "commands": [
-          "npx rimraf .coverage*",
+          "npx -y rimraf .coverage*",
           "uv run coverage run -p -m unittest discover -v -s ./tests",
           "mpiexec -n 2 uv run coverage run -p -m unittest discover -v -s ./tests",
           "uv run coverage combine",
@@ -75,7 +75,7 @@
       "outputs": ["{projectRoot}/docs/_build/iso-html"],
       "options": {
         "commands": [
-          "npx rimraf _build/iso-html/",
+          "npx -y rimraf _build/iso-html/",
           "uv run sphinx-build -v -b html . _build/iso-html"
         ],
         "parallel": false,
@@ -89,8 +89,8 @@
       "outputs": ["{projectRoot}/docs/_build/html"],
       "options": {
         "commands": [
-          "npx rimraf _build/html/",
-          "npx cross-env BSB_LOCAL_INTERSPHINX_ONLY=true uv run sphinx-build -nW -b html . _build/html"
+          "npx -y rimraf _build/html/",
+          "npx -y cross-env BSB_LOCAL_INTERSPHINX_ONLY=true uv run sphinx-build -nW -b html . _build/html"
         ],
         "parallel": false,
         "cwd": "{projectRoot}/docs/"

--- a/packages/bsb-json/project.json
+++ b/packages/bsb-json/project.json
@@ -58,7 +58,7 @@
       "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
         "commands": [
-          "npx rimraf .coverage*",
+          "npx -y rimraf .coverage*",
           "uv run coverage run -p -m unittest discover -v -s ./tests",
           "mpiexec -n 2 uv run coverage run -p -m unittest discover -v -s ./tests",
           "uv run coverage combine",
@@ -75,7 +75,7 @@
       "outputs": ["{projectRoot}/docs/_build/iso-html"],
       "options": {
         "commands": [
-          "npx rimraf _build/iso-html/",
+          "npx -y rimraf _build/iso-html/",
           "uv run sphinx-build -b html . _build/iso-html"
         ],
         "parallel": false,
@@ -89,8 +89,8 @@
       "outputs": ["{projectRoot}/docs/_build/html"],
       "options": {
         "commands": [
-          "npx rimraf _build/html/",
-          "npx cross-env BSB_LOCAL_INTERSPHINX_ONLY=true uv run sphinx-build -nW -b html . _build/html"
+          "npx -y rimraf _build/html/",
+          "npx -y cross-env BSB_LOCAL_INTERSPHINX_ONLY=true uv run sphinx-build -nW -b html . _build/html"
         ],
         "parallel": false,
         "cwd": "{projectRoot}/docs/"

--- a/packages/bsb-nest/install-nest.sh
+++ b/packages/bsb-nest/install-nest.sh
@@ -22,7 +22,7 @@ if [ ! -d "$NEST_FOLDER" ]; then
 fi
 
 # Install bsb-nest NEST dependency GSL
-apt install libgsl-dev -y
+sudo apt install libgsl-dev -y
 
 # Checkout NEST version
 cd "$NEST_FOLDER"

--- a/packages/bsb-nest/install-nest.sh
+++ b/packages/bsb-nest/install-nest.sh
@@ -21,6 +21,9 @@ if [ ! -d "$NEST_FOLDER" ]; then
   git clone https://github.com/nest/nest-simulator $NEST_FOLDER
 fi
 
+# Install bsb-nest NEST dependency GSL
+apt install libgsl-dev -y
+
 # Checkout NEST version
 cd "$NEST_FOLDER"
 git checkout tags/v"$NEST_VERSION"

--- a/packages/bsb-nest/install-nest.sh
+++ b/packages/bsb-nest/install-nest.sh
@@ -21,7 +21,7 @@ if [ ! -d "$NEST_FOLDER" ]; then
   git clone https://github.com/nest/nest-simulator $NEST_FOLDER
 fi
 
-# Install bsb-nest NEST dependency GSL
+# Install bsb-nest NEST dependency GSL for conductance-based NEST models
 sudo apt install libgsl-dev -y
 
 # Checkout NEST version

--- a/packages/bsb-nest/project.json
+++ b/packages/bsb-nest/project.json
@@ -85,7 +85,7 @@
       ],
       "options": {
         "commands": [
-          "npx rimraf .coverage*",
+          "npx -y rimraf .coverage*",
           "uv run coverage run -p -m unittest discover -v -s ./tests",
           "mpiexec -n 2 uv run coverage run -p -m unittest discover -v -s ./tests",
           "uv run coverage combine",
@@ -102,7 +102,7 @@
       "outputs": ["{projectRoot}/docs/_build/iso-html"],
       "options": {
         "commands": [
-          "npx rimraf _build/iso-html/",
+          "npx -y rimraf _build/iso-html/",
           "uv run sphinx-build -b html . _build/iso-html"
         ],
         "parallel": false,
@@ -116,8 +116,8 @@
       "outputs": ["{projectRoot}/docs/_build/html"],
       "options": {
         "commands": [
-          "npx rimraf _build/html/",
-          "npx cross-env BSB_LOCAL_INTERSPHINX_ONLY=true uv run sphinx-build -nW -b html . _build/html"
+          "npx -y rimraf _build/html/",
+          "npx -y cross-env BSB_LOCAL_INTERSPHINX_ONLY=true uv run sphinx-build -nW -b html . _build/html"
         ],
         "parallel": false,
         "cwd": "{projectRoot}/docs/"

--- a/packages/bsb-neuron/project.json
+++ b/packages/bsb-neuron/project.json
@@ -60,7 +60,7 @@
       ],
       "options": {
         "commands": [
-          "npx rimraf .coverage*",
+          "npx -y rimraf .coverage*",
           "uv run coverage run -p -m unittest discover -v -s ./tests",
           "mpiexec -n 2 uv run coverage run -p -m unittest discover -v -s ./tests",
           "uv run coverage combine",
@@ -77,7 +77,7 @@
       "outputs": ["{projectRoot}/docs/_build/iso-html"],
       "options": {
         "commands": [
-          "npx rimraf _build/iso-html/",
+          "npx -y rimraf _build/iso-html/",
           "uv run sphinx-build -b html . _build/iso-html"
         ],
         "parallel": false,
@@ -91,8 +91,8 @@
       "outputs": ["{projectRoot}/docs/_build/html"],
       "options": {
         "commands": [
-          "npx rimraf _build/html/",
-          "npx cross-env BSB_LOCAL_INTERSPHINX_ONLY=true uv run sphinx-build -nW -b html . _build/html"
+          "npx -y rimraf _build/html/",
+          "npx -y cross-env BSB_LOCAL_INTERSPHINX_ONLY=true uv run sphinx-build -nW -b html . _build/html"
         ],
         "parallel": false,
         "cwd": "{projectRoot}/docs/"

--- a/packages/bsb-test/project.json
+++ b/packages/bsb-test/project.json
@@ -58,7 +58,7 @@
       "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
         "commands": [
-          "npx rimraf .coverage*",
+          "npx -y rimraf .coverage*",
           "uv run coverage run -p -m unittest discover -v -s ./tests",
           "mpiexec -n 2 uv run coverage run -p -m unittest discover -v -s ./tests",
           "uv run coverage combine",
@@ -75,7 +75,7 @@
       "outputs": ["{projectRoot}/docs/_build/iso-html"],
       "options": {
         "commands": [
-          "npx rimraf _build/iso-html/",
+          "npx -y rimraf _build/iso-html/",
           "uv run sphinx-build -b html . _build/iso-html"
         ],
         "parallel": false,
@@ -89,8 +89,8 @@
       "outputs": ["{projectRoot}/docs/_build/html"],
       "options": {
         "commands": [
-          "npx rimraf _build/html/",
-          "npx cross-env BSB_LOCAL_INTERSPHINX_ONLY=true uv run sphinx-build -nW -b html . _build/html"
+          "npx -y rimraf _build/html/",
+          "npx -y cross-env BSB_LOCAL_INTERSPHINX_ONLY=true uv run sphinx-build -nW -b html . _build/html"
         ],
         "parallel": false,
         "cwd": "{projectRoot}/docs/"

--- a/packages/bsb-yaml/project.json
+++ b/packages/bsb-yaml/project.json
@@ -58,7 +58,7 @@
       "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
         "commands": [
-          "npx rimraf .coverage*",
+          "npx -y rimraf .coverage*",
           "uv run coverage run -p -m unittest discover -v -s ./tests",
           "mpiexec -n 2 uv run coverage run -p -m unittest discover -v -s ./tests",
           "uv run coverage combine",
@@ -75,7 +75,7 @@
       "outputs": ["{projectRoot}/docs/_build/iso-html"],
       "options": {
         "commands": [
-          "npx rimraf _build/iso-html/",
+          "npx -y rimraf _build/iso-html/",
           "uv run sphinx-build -b html . _build/iso-html"
         ],
         "parallel": false,
@@ -89,8 +89,8 @@
       "outputs": ["{projectRoot}/docs/_build/html"],
       "options": {
         "commands": [
-          "npx rimraf _build/html/",
-          "npx cross-env BSB_LOCAL_INTERSPHINX_ONLY=true uv run sphinx-build -nW -b html . _build/html"
+          "npx -y rimraf _build/html/",
+          "npx -y cross-env BSB_LOCAL_INTERSPHINX_ONLY=true uv run sphinx-build -nW -b html . _build/html"
         ],
         "parallel": false,
         "cwd": "{projectRoot}/docs/"

--- a/packages/bsb/project.json
+++ b/packages/bsb/project.json
@@ -42,7 +42,7 @@
       "outputs": ["{projectRoot}/docs/_build/iso-html"],
       "options": {
         "commands": [
-          "npx rimraf _build/iso-html/",
+          "npx -y rimraf _build/iso-html/",
           "uv run sphinx-build -v -b html . _build/iso-html"
         ],
         "parallel": false,
@@ -65,8 +65,8 @@
       "outputs": ["{projectRoot}/docs/_build/html"],
       "options": {
         "commands": [
-          "npx rimraf _build/html/",
-          "npx cross-env BSB_LOCAL_INTERSPHINX_ONLY=true uv run sphinx-build -nW -b html . _build/html"
+          "npx -y rimraf _build/html/",
+          "npx -y cross-env BSB_LOCAL_INTERSPHINX_ONLY=true uv run sphinx-build -nW -b html . _build/html"
         ],
         "parallel": false,
         "cwd": "{projectRoot}/docs/"


### PR DESCRIPTION
## Describe the work done

Added `-y` flags to all npx to ensure it runs without user interaction (closes #156). Also added the install of the required GSL library to `install_nest.sh`, ironically, this now introduces required user interaction for the `sudo` password, and I can't think of a way around it (closes #155).

<!-- readthedocs-preview nrn-patch start -->
----
📚 Documentation preview 📚: https://nrn-patch--157.org.readthedocs.build/en/157/

<!-- readthedocs-preview nrn-patch end -->

<!-- readthedocs-preview bsb-yaml start -->
----
📚 Documentation preview 📚: https://bsb-yaml--157.org.readthedocs.build/en/157/

<!-- readthedocs-preview bsb-yaml end -->

<!-- readthedocs-preview nmodl-glia start -->
----
📚 Documentation preview 📚: https://nmodl-glia--157.org.readthedocs.build/en/157/

<!-- readthedocs-preview nmodl-glia end -->

<!-- readthedocs-preview bsb start -->
----
📚 Documentation preview 📚: https://bsb--157.org.readthedocs.build/en/157/

<!-- readthedocs-preview bsb end -->

<!-- readthedocs-preview arborize start -->
----
📚 Documentation preview 📚: https://arborize--157.org.readthedocs.build/en/157/

<!-- readthedocs-preview arborize end -->

<!-- readthedocs-preview bsb-core start -->
----
📚 Documentation preview 📚: https://bsb-core--157.org.readthedocs.build/en/157/

<!-- readthedocs-preview bsb-core end -->

<!-- readthedocs-preview bsb-nest start -->
----
📚 Documentation preview 📚: https://bsb-nest--157.org.readthedocs.build/en/157/

<!-- readthedocs-preview bsb-nest end -->

<!-- readthedocs-preview bsb-arbor start -->
----
📚 Documentation preview 📚: https://bsb-arbor--157.org.readthedocs.build/en/157/

<!-- readthedocs-preview bsb-arbor end -->

<!-- readthedocs-preview bsb-json start -->
----
📚 Documentation preview 📚: https://bsb-json--157.org.readthedocs.build/en/157/

<!-- readthedocs-preview bsb-json end -->