### PR TITLE
fix(release): bump nightly

### DIFF
--- a/libs/nmodl-glia/glia/_glia.py
+++ b/libs/nmodl-glia/glia/_glia.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import subprocess
 import sys
+import time
 import typing
 import warnings
 from functools import lru_cache, wraps
@@ -417,8 +418,16 @@ class Glia:
         os.makedirs(get_data_path(), exist_ok=True)
         clear_cache()
         create_preferences()
+        could_lock = False
+        while not could_lock:
+            try:
+                with open(os.path.join(get_data_path(), "lock_install"), "x"):
+                    could_lock = True
+            except FileExistsError as _:
+                time.sleep(0.1)
         if not Path(get_local_pkg_path()).exists():
             create_local_package()
+        os.remove(os.path.join(get_data_path(), "lock_install"))
         # Environment cache path install
         shutil.rmtree(get_cache_path(), ignore_errors=True)
         os.makedirs(get_cache_path(), exist_ok=True)

--- a/libs/nmodl-glia/pyproject.toml
+++ b/libs/nmodl-glia/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
   "black>=24.0",
   "toml~=0.10",
   "packaging~=24.0",
-  "neuron-nightly==9.0a1.dev1422; sys_platform != 'win32'",
+  "neuron-nightly==9.0a1.dev1478; sys_platform != 'win32'",
   "importlib_metadata~=6.5"
 ]
 

--- a/libs/nmodl-glia/pyproject.toml
+++ b/libs/nmodl-glia/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
   "black>=24.0",
   "toml~=0.10",
   "packaging~=24.0",
-  "neuron-nightly==9.0a1.dev1478; sys_platform != 'win32'",
+  "neuron-nightly==9.0a1.dev1485; sys_platform != 'win32'",
   "importlib_metadata~=6.5"
 ]
 

--- a/libs/nrn-patch/docs/conf.py
+++ b/libs/nrn-patch/docs/conf.py
@@ -48,8 +48,9 @@ templates_path = ["_templates"]
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = []
 
+# TODO: Use latest instead of the fixed version. https://github.com/dbbs-lab/bsb/issues/168
 intersphinx_mapping = {
-    "neuron": ("https://nrn.readthedocs.io/en/latest/", None),
+    "neuron": ("https://nrn.readthedocs.io/en/8.2.7/", None),
     **_project.intersphinx,
 }
 

--- a/libs/nrn-patch/pyproject.toml
+++ b/libs/nrn-patch/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   "packaging~=24.0",
   "errr~=1.2",
   "numpy~=1.21",
-  "neuron-nightly==9.0a1.dev1478; sys_platform != 'win32'"
+  "neuron-nightly==9.0a1.dev1485; sys_platform != 'win32'"
 ]
 
   [[project.authors]]

--- a/libs/nrn-patch/pyproject.toml
+++ b/libs/nrn-patch/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   "packaging~=24.0",
   "errr~=1.2",
   "numpy~=1.21",
-  "neuron-nightly==9.0a1.dev1422; sys_platform != 'win32'"
+  "neuron-nightly==9.0a1.dev1478; sys_platform != 'win32'"
 ]
 
   [[project.authors]]


### PR DESCRIPTION
## Describe the work done

`neuron-nightly` seems to keep only the last 50 versions, so we'll have to bump our dependency every 50 days until they release NEURON 9.0 :)

<!-- readthedocs-preview nmodl-glia start -->
----
📚 Documentation preview 📚: https://nmodl-glia--165.org.readthedocs.build/en/165/

<!-- readthedocs-preview nmodl-glia end -->

<!-- readthedocs-preview nrn-patch start -->
----
📚 Documentation preview 📚: https://nrn-patch--165.org.readthedocs.build/en/165/

<!-- readthedocs-preview nrn-patch end -->