### PR TITLE
fix: correctly call synapse point process in arborize neuron builder 

### DIFF
--- a/libs/arborize/arborize/builders/_neuron.py
+++ b/libs/arborize/arborize/builders/_neuron.py
@@ -114,7 +114,7 @@ class NeuronModel:
         if source is None:
             return p.ParallelCon(gid, synapse, **kwargs)
         else:
-            spp = synapse._point_process
+            spp = synapse._pp
             p.parallel.target_var(spp, getattr(spp, "_ref_" + source), gid)
 
     def insert_transmitter(

--- a/libs/arborize/tests/test_neuron_models.py
+++ b/libs/arborize/tests/test_neuron_models.py
@@ -57,6 +57,24 @@ class TestModelBuilding(SchematicsFixture, unittest.TestCase):
         self.assertFalse(min(r) == max(r), "No synaptic currents detected")
         self.assertTrue(min(r_nosyn) == max(r_nosyn), "Synaptic currents detected")
 
+    def test_receiver(self):
+        cell = neuron_build(self.p75_expsyn)
+        cell.insert_receiver(1, "ExpSyn", (0, 0))
+        synapse = cell.get_location((0, 0)).section.synapses[0]
+        self.assertEqual(synapse.gid, 1, "GId should be 1")
+        synapse.stimulate(start=0, number=3, interval=10)
+        r = cell.sections[0].record()
+        p.run(100)
+        self.assertFalse(min(r) == max(r), "No synaptic currents detected")
+        cell2 = neuron_build(self.p75_expsyn)
+        cell2.insert_receiver(1, "ExpSyn", (0, 0), source="i")
+        synapse2 = cell2.get_location((0, 0)).section.synapses[0]
+        self.assertEqual(
+            synapse2._pp._interpreter.parallel._transfer_max,
+            1,
+            "transfer_max should be 1",
+        )
+
     def test_cable_building(self):
         self.cell010.definition = define_model(
             {

--- a/libs/arborize/tests/test_neuron_models.py
+++ b/libs/arborize/tests/test_neuron_models.py
@@ -61,8 +61,6 @@ class TestModelBuilding(SchematicsFixture, unittest.TestCase):
 
     def test_receiver(self):
         cell = neuron_build(self.p75_expsyn)
-        cell_transmitter = neuron_build(self.p75_expsyn)
-        cell_transmitter.insert_transmitter(10, (0, 0), source="v")
         cell.insert_receiver(10, "ExpSyn", (0, 0))
         synapse = cell.get_location((0, 0)).section.synapses[0]
         self.assertEqual(synapse.gid, 10, "GId should be 1")
@@ -71,9 +69,7 @@ class TestModelBuilding(SchematicsFixture, unittest.TestCase):
         p.run(100)
         self.assertFalse(min(r) == max(r), "No synaptic currents detected")
         cell2 = neuron_build(self.p75_expsyn)
-        source_id = cell_transmitter.get_location((0, 0)).section._source_gid
-        print(f"Source: {source_id}")
-        cell2.insert_receiver(source_id, "ExpSyn", (0, 0), source="i")
+        cell2.insert_receiver(10, "ExpSyn", (0, 0), source="i")
         synapse2 = cell2.get_location((0, 0)).section.synapses[0]
         self.assertEqual(
             synapse2._pp._interpreter.parallel._transfer_max,

--- a/libs/arborize/tests/test_neuron_models.py
+++ b/libs/arborize/tests/test_neuron_models.py
@@ -45,6 +45,7 @@ class TestModelBuilding(SchematicsFixture, unittest.TestCase):
         syn = cell.insert_synapse("ExpSyn", (0, 0))
         with self.assertRaises(UnknownLocationError):
             cell.insert_synapse("ExpSyn", (-1, 0))
+        syn._pp._interpreter.parallel.gid_clear()
         syn.stimulate(start=0, number=3, interval=10)
         r = cell.sections[0].record()
         r_nosyn = cell_nosyn.sections[0].record()

--- a/libs/nmodl-glia/pyproject.toml
+++ b/libs/nmodl-glia/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
   "black>=24.0",
   "toml~=0.10",
   "packaging~=24.0",
-  "neuron-nightly==9.0a1.dev1485; sys_platform != 'win32'",
+  "NEURON>=9.0; sys_platform != 'win32'",
   "importlib_metadata~=6.5"
 ]
 

--- a/libs/nrn-patch/pyproject.toml
+++ b/libs/nrn-patch/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   "packaging~=24.0",
   "errr~=1.2",
   "numpy~=1.21",
-  "neuron-nightly==9.0a1.dev1485; sys_platform != 'win32'"
+  "NEURON>=9.0; sys_platform != 'win32'",
 ]
 
   [[project.authors]]


### PR DESCRIPTION
## Describe the work done
It was pointed out that the correct attribute to call is `._pp`. 

Change the dependencies from neuron-nightly to NEURON 9 ( in nmodl-glia and nrn-patch ).

## List which issues this resolves:

closes #179 

## Tasks
* [X] Add Test


<!-- readthedocs-preview bsb-test start -->
----
📚 Documentation preview 📚: https://bsb-test--181.org.readthedocs.build/en/181/

<!-- readthedocs-preview bsb-test end -->

<!-- readthedocs-preview bsb-neuron start -->
----
📚 Documentation preview 📚: https://bsb-neuron--181.org.readthedocs.build/en/181/

<!-- readthedocs-preview bsb-neuron end -->

<!-- readthedocs-preview bsb-nest start -->
----
📚 Documentation preview 📚: https://bsb-nest--181.org.readthedocs.build/en/181/

<!-- readthedocs-preview bsb-nest end -->

<!-- readthedocs-preview bsb-arbor start -->
----
📚 Documentation preview 📚: https://bsb-arbor--181.org.readthedocs.build/en/181/

<!-- readthedocs-preview bsb-arbor end -->

<!-- readthedocs-preview nrn-patch start -->
----
📚 Documentation preview 📚: https://nrn-patch--181.org.readthedocs.build/en/181/

<!-- readthedocs-preview nrn-patch end -->

<!-- readthedocs-preview bsb-core start -->
----
📚 Documentation preview 📚: https://bsb-core--181.org.readthedocs.build/en/181/

<!-- readthedocs-preview bsb-core end -->

<!-- readthedocs-preview bsb start -->
----
📚 Documentation preview 📚: https://bsb--181.org.readthedocs.build/en/181/

<!-- readthedocs-preview bsb end -->

<!-- readthedocs-preview arborize start -->
----
📚 Documentation preview 📚: https://arborize--181.org.readthedocs.build/en/181/

<!-- readthedocs-preview arborize end -->