### PR TITLE
fix: bump bsb versions in toml

### DIFF
--- a/examples/atlas-modeling/pyproject.toml
+++ b/examples/atlas-modeling/pyproject.toml
@@ -5,12 +5,12 @@ description = "BSB example on Allen Brain Atlas integration"
 readme = "README.md"
 requires-python = ">=3.10,<4"
 dependencies = [
-    "bsb~=6.0",
+    "bsb~=7.0",
 ]
 
 [dependency-groups]
 test = [
-    "bsb-test~=6.0",
+    "bsb-test~=7.0",
 ]
 
 [tool.uv]

--- a/examples/cell-labeling/pyproject.toml
+++ b/examples/cell-labeling/pyproject.toml
@@ -5,12 +5,12 @@ description = "BSB cell labeling example"
 readme = "README.md"
 requires-python = ">=3.10,<4"
 dependencies = [
-    "bsb~=6.0"
+    "bsb~=7.0"
 ]
 
 [dependency-groups]
 test = [
-    "bsb-test~=6.0",
+    "bsb-test~=7.0",
 ]
 
 [tool.uv]

--- a/examples/getting-started/pyproject.toml
+++ b/examples/getting-started/pyproject.toml
@@ -5,12 +5,12 @@ description = "BSB getting started example"
 readme = "README.md"
 requires-python = ">=3.10,<4"
 dependencies = [
-    "bsb~=6.0",
+    "bsb~=7.0",
 ]
 
 [dependency-groups]
 test = [
-    "bsb-test~=6.0",
+    "bsb-test~=7.0",
 ]
 
 [tool.uv]

--- a/examples/include-morphologies/pyproject.toml
+++ b/examples/include-morphologies/pyproject.toml
@@ -5,13 +5,13 @@ description = "BSB add morphologies example"
 readme = "README.md"
 requires-python = ">=3.10,<4"
 dependencies = [
-    "bsb~=6.0",
+    "bsb~=7.0",
     "matplotlib>=3.10.6",
 ]
 
 [dependency-groups]
 test = [
-    "bsb-test~=6.0",
+    "bsb-test~=7.0",
 ]
 
 [tool.uv]

--- a/examples/manipulate-morphologies/pyproject.toml
+++ b/examples/manipulate-morphologies/pyproject.toml
@@ -5,12 +5,12 @@ description = "BSB manipulate morphologies example"
 readme = "README.md"
 requires-python = ">=3.10,<4"
 dependencies = [
-    "bsb~=6.0",
+    "bsb~=7.0",
 ]
 
 [dependency-groups]
 test = [
-    "bsb-test~=6.0",
+    "bsb-test~=7.0",
 ]
 
 [tool.uv]

--- a/examples/nest-simulation/pyproject.toml
+++ b/examples/nest-simulation/pyproject.toml
@@ -5,14 +5,14 @@ description = "BSB NEST simulation examples"
 readme = "README.md"
 requires-python = ">=3.10,<4"
 dependencies = [
-    "bsb~=6.0",
-    "bsb-nest~=6.0",
+    "bsb~=7.0",
+    "bsb-nest~=7.0",
     "matplotlib>=3.10.6",
 ]
 
 [dependency-groups]
 test = [
-    "bsb-test~=6.0",
+    "bsb-test~=7.0",
 ]
 
 [tool.uv]

--- a/examples/neuron-simulation/pyproject.toml
+++ b/examples/neuron-simulation/pyproject.toml
@@ -5,15 +5,15 @@ description = "BSB Neuron simulation examples"
 readme = "README.md"
 requires-python = ">=3.10,<4"
 dependencies = [
-    "bsb~=6.0",
-    "bsb-neuron[parallel]~=6.0",  # parallel is required see issue #188
+    "bsb~=7.0",
+    "bsb-neuron[parallel]~=7.0",  # parallel is required see issue #188
     "dbbs-catalogue~=6.0",
     "matplotlib>=3.10.6",
 ]
 
 [dependency-groups]
 test = [
-    "bsb-test~=6.0",
+    "bsb-test~=7.0",
 ]
 
 [tool.uv]

--- a/examples/writing-components/pyproject.toml
+++ b/examples/writing-components/pyproject.toml
@@ -5,12 +5,12 @@ description = "BSB example on component writing"
 readme = "README.md"
 requires-python = ">=3.10,<4"
 dependencies = [
-    "bsb~=6.0",
+    "bsb~=7.0",
 ]
 
 [dependency-groups]
 test = [
-    "bsb-test~=6.0",
+    "bsb-test~=7.0",
 ]
 
 [tool.uv]

--- a/libs/arborize/pyproject.toml
+++ b/libs/arborize/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "numpy~=1.21",
   "errr~=1.2",
   "morphio>=3.3.6,<4",
-  "bsb-core~=6.0"
+  "bsb-core~=7.0"
 ]
 
   [[project.authors]]
@@ -28,13 +28,13 @@ dependencies = [
   [project.optional-dependencies]
   parallel = [ "mpi4py~=3.0" ]
   bluepyopt = [ "bluepyopt~=1.14", "dill>=0.3.8" ]
-  neuron = [ "nrn-patch~=6.0", "nmodl-glia[neuron]~=6.0" ]
-  arbor = [ "arbor~=0.10", "nmodl-glia[arbor]~=6.0" ]
+  neuron = [ "nrn-patch~=7.0", "nmodl-glia[neuron]~=7.0" ]
+  arbor = [ "arbor~=0.10", "nmodl-glia[arbor]~=7.0" ]
 
 [dependency-groups]
 docs = [
   "sphinx~=8.1",
-  "sphinxext-bsb~=6.0",
+  "sphinxext-bsb~=7.0",
   "furo~=2024.0",
   "sphinxemoji~=0.3",
   "sphinx-copybutton~=0.5"

--- a/libs/nmodl-glia/pyproject.toml
+++ b/libs/nmodl-glia/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
 
   [project.optional-dependencies]
   parallel = [ "mpi4py~=3.0" ]
-  neuron = [ "nrn-patch~=6.0" ]
+  neuron = [ "nrn-patch~=7.0" ]
   arbor = [ "arbor~=0.10" ]
 
   [project.scripts]
@@ -41,7 +41,7 @@ dependencies = [
 [dependency-groups]
 docs = [
   "sphinx~=8.1",
-  "sphinxext-bsb~=6.0",
+  "sphinxext-bsb~=7.0",
   "furo~=2024.0",
   "sphinxemoji~=0.2",
   "sphinx_design~=0.5",

--- a/libs/nrn-patch/pyproject.toml
+++ b/libs/nrn-patch/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
 ]
 requires-python = ">=3.10,<4"
 dependencies = [
-  "nmodl-glia[neuron]~=6.0",
+  "nmodl-glia[neuron]~=7.0",
   "packaging~=24.0",
   "errr~=1.2",
   "numpy~=1.21",
@@ -36,7 +36,7 @@ extensions = "patch.extensions:package"
 test = [ "nrn-patch[parallel]", "coverage~=7.0" ]
 docs = [
   "sphinx~=8.1",
-  "sphinxext-bsb~=6.0",
+  "sphinxext-bsb~=7.0",
   "helveg--sphinx-code-tabs~=0.2",
   "furo~=2024.0"
 ]

--- a/libs/sphinxext-bsb/pyproject.toml
+++ b/libs/sphinxext-bsb/pyproject.toml
@@ -33,7 +33,7 @@ readme = "README.md"
 classifiers = [
   "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)"
 ]
-dependencies = [ "bsb-core~=6.0", "sphinx>=8.1", "sphinx-design~=0.6" ]
+dependencies = [ "bsb-core~=7.0", "sphinx>=8.1", "sphinx-design~=0.6" ]
 
   [project.license]
   file = "LICENSE"

--- a/packages/bsb-arbor/pyproject.toml
+++ b/packages/bsb-arbor/pyproject.toml
@@ -13,10 +13,10 @@ classifiers = [
 ]
 dependencies = [
   "numpy~=1.21",
-  "bsb-core~=6.0",
-  "arborize~=6.0",
+  "bsb-core~=7.0",
+  "arborize~=7.0",
   "arbor~=0.10; sys_platform != 'win32'",
-  "arborize[arbor]~=6.0; sys_platform != 'win32'"
+  "arborize[arbor]~=7.0; sys_platform != 'win32'"
 ]
 
   [[project.authors]]
@@ -36,11 +36,11 @@ arbor = "bsb_arbor"
 [dependency-groups]
 test = [
   "bsb-core[parallel]",
-  "bsb-hdf5~=6.0",
-  "bsb-test~=6.0",
+  "bsb-hdf5~=7.0",
+  "bsb-test~=7.0",
   "coverage>=7.3"
 ]
-docs = [ "furo~=2024.0", "sphinxext-bsb~=6.0" ]
+docs = [ "furo~=2024.0", "sphinxext-bsb~=7.0" ]
 dev = [
   "bsb-arbor[test,docs]",
   "pre-commit~=3.5",

--- a/packages/bsb-core/pyproject.toml
+++ b/packages/bsb-core/pyproject.toml
@@ -70,19 +70,19 @@ quiet = "bsb._options:quiet"
 [dependency-groups]
 test = [
   "bsb-core[parallel]",
-  "bsb-arbor~=6.0; sys_platform != 'win32'",
-  "bsb-hdf5~=6.0",
-  "bsb-json~=6.0",
-  "bsb-test~=6.0",
+  "bsb-arbor~=7.0; sys_platform != 'win32'",
+  "bsb-hdf5~=7.0",
+  "bsb-json~=7.0",
+  "bsb-test~=7.0",
   "coverage>=7.3"
 ]
 docs = [
   "furo~=2024.4",
   "sphinxemoji~=0.3",
   "sphinx-copybutton~=0.5",
-  "bsb-json~=6.0",
-  "bsb-yaml~=6.0",
-  "sphinxext-bsb~=6.0"
+  "bsb-json~=7.0",
+  "bsb-yaml~=7.0",
+  "sphinxext-bsb~=7.0"
 ]
 dev = [
   "pre-commit~=3.5",

--- a/packages/bsb-core/tests/test_util.py
+++ b/packages/bsb-core/tests/test_util.py
@@ -5,6 +5,7 @@ from bsb_test import (
     FixedPosConfigFixture,
     NumpyTestCase,
     RandomStorageFixture,
+    skip_parallel,
     skipIfOffline,
 )
 from scipy.spatial.transform import Rotation
@@ -69,6 +70,7 @@ class TestRotationUtils(unittest.TestCase):
 
 
 class TestUriSchemes(RandomStorageFixture, unittest.TestCase, engine_name="fs"):
+    @skip_parallel  # see https://github.com/dbbs-lab/bsb/issues/197
     @skipIfOffline(scheme=NeuroMorphoScheme())
     def test_nm_scheme(self):
         file = FileDependency(

--- a/packages/bsb-hdf5/pyproject.toml
+++ b/packages/bsb-hdf5/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = [ "description" ]
 classifiers = [
   "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)"
 ]
-dependencies = [ "bsb-core~=6.0" ]
+dependencies = [ "bsb-core~=7.0" ]
 
   [[project.authors]]
   name = "Robin De Schepper"
@@ -28,13 +28,13 @@ dependencies = [ "bsb-core~=6.0" ]
 hdf5 = "bsb_hdf5"
 
 [dependency-groups]
-test = [ "bsb-core[parallel]", "bsb-test~=6.0", "coverage>=7.3" ]
+test = [ "bsb-core[parallel]", "bsb-test~=7.0", "coverage>=7.3" ]
 docs = [
   "sphinxemoji~=0.2",
   "toml~=0.10",
   "furo~=2024.0",
   "sphinx-copybutton~=0.5",
-  "sphinxext-bsb~=6.0"
+  "sphinxext-bsb~=7.0"
 ]
 dev = [ "pre-commit~=3.5", "ruff>=0.8.2" ]
 

--- a/packages/bsb-json/pyproject.toml
+++ b/packages/bsb-json/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = [ "description" ]
 classifiers = [
   "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)"
 ]
-dependencies = [ "bsb-core~=6.0" ]
+dependencies = [ "bsb-core~=7.0" ]
 
   [[project.authors]]
   name = "Robin De Schepper"
@@ -32,7 +32,7 @@ json_templates = "bsb_json.templates"
 
 [dependency-groups]
 test = [ "bsb-core[parallel]", "bsb-test~=4.0", "coverage>=7.3" ]
-docs = [ "furo~=2024.0", "sphinxext-bsb~=6.0" ]
+docs = [ "furo~=2024.0", "sphinxext-bsb~=7.0" ]
 dev = [ "pre-commit~=3.5", "ruff>=0.8.2" ]
 
 [tool.uv]

--- a/packages/bsb-nest/pyproject.toml
+++ b/packages/bsb-nest/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = [ "description" ]
 classifiers = [
   "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)"
 ]
-dependencies = [ "bsb-core~=6.0" ]
+dependencies = [ "bsb-core~=7.0" ]
 
   [[project.authors]]
   name = "Robin De Schepper"
@@ -33,12 +33,12 @@ nest = "bsb_nest"
 [dependency-groups]
 test = [
   "bsb-core[parallel]",
-  "bsb-test~=6.0",
-  "bsb-hdf5~=6.0",
-  "bsb-arbor~=6.0",
+  "bsb-test~=7.0",
+  "bsb-hdf5~=7.0",
+  "bsb-arbor~=7.0",
   "coverage~=7.0"
 ]
-docs = [ "furo~=2024.0", "sphinxext-bsb~=6.0" ]
+docs = [ "furo~=2024.0", "sphinxext-bsb~=7.0" ]
 dev = [ "pre-commit~=3.5", "snakeviz~=2.1", "ruff>=0.8.2" ]
 
 [tool.uv]

--- a/packages/bsb-neuron/pyproject.toml
+++ b/packages/bsb-neuron/pyproject.toml
@@ -12,9 +12,9 @@ classifiers = [
   "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)"
 ]
 dependencies = [
-  "bsb-core~=6.0",
-  "nrn-patch~=6.0; sys_platform != 'win32'",
-  "arborize[neuron]~=6.0; sys_platform != 'win32'"
+  "bsb-core~=7.0",
+  "nrn-patch~=7.0; sys_platform != 'win32'",
+  "arborize[neuron]~=7.0; sys_platform != 'win32'"
 ]
 
   [[project.authors]]
@@ -37,11 +37,11 @@ neuron = "bsb_neuron"
 [dependency-groups]
 test = [
   "bsb-core[parallel]",
-  "bsb-test~=6.0",
-  "bsb-hdf5~=6.0",
+  "bsb-test~=7.0",
+  "bsb-hdf5~=7.0",
   "coverage~=7.0"
 ]
-docs = [ "furo~=2024.0", "sphinxext-bsb~=6.0" ]
+docs = [ "furo~=2024.0", "sphinxext-bsb~=7.0" ]
 dev = [ "pre-commit~=3.5", "snakeviz~=2.1", "ruff>=0.8.2" ]
 
 [tool.uv]

--- a/packages/bsb-test/pyproject.toml
+++ b/packages/bsb-test/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = [ "description" ]
 classifiers = [
   "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)"
 ]
-dependencies = [ "bsb-core~=6.0" ]
+dependencies = [ "bsb-core~=7.0" ]
 
   [[project.authors]]
   name = "Robin De Schepper"
@@ -25,8 +25,8 @@ dependencies = [ "bsb-core~=6.0" ]
   file = "LICENSE"
 
 [dependency-groups]
-test = [ "bsb-core[parallel]", "bsb-hdf5~=6.0", "coverage>=7.3" ]
-docs = [ "furo~=2024.0", "sphinxext-bsb~=6.0" ]
+test = [ "bsb-core[parallel]", "bsb-hdf5~=7.0", "coverage>=7.3" ]
+docs = [ "furo~=2024.0", "sphinxext-bsb~=7.0" ]
 dev = [ "pre-commit~=3.5", "ruff>=0.8.2", "snakeviz~=2.1" ]
 
 [tool.uv]

--- a/packages/bsb-yaml/pyproject.toml
+++ b/packages/bsb-yaml/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = [ "description" ]
 classifiers = [
   "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)"
 ]
-dependencies = [ "bsb-core~=6.0", "PyYAML~=6.0", "pydantic" ]
+dependencies = [ "bsb-core~=7.0", "PyYAML~=6.0", "pydantic" ]
 
   [[project.authors]]
   name = "Robin De Schepper"
@@ -32,7 +32,7 @@ yaml_templates = "bsb_yaml.templates"
 
 [dependency-groups]
 test = [ "bsb-core[parallel]", "coverage>=7.3" ]
-docs = [ "furo~=2024.0", "sphinxext-bsb~=6.0" ]
+docs = [ "furo~=2024.0", "sphinxext-bsb~=7.0" ]
 dev = [ "pre-commit~=3.5", "ruff>=0.8.2" ]
 
 [tool.uv]

--- a/packages/bsb/pyproject.toml
+++ b/packages/bsb/pyproject.toml
@@ -12,10 +12,10 @@ classifiers = [
   "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)"
 ]
 dependencies = [
-  "bsb-core~=6.0",
-  "bsb-hdf5~=6.0",
-  "bsb-json~=6.0",
-  "bsb-yaml~=6.0"
+  "bsb-core~=7.0",
+  "bsb-hdf5~=7.0",
+  "bsb-json~=7.0",
+  "bsb-yaml~=7.0"
 ]
 
   [[project.authors]]
@@ -35,9 +35,9 @@ dependencies = [
 
   [project.optional-dependencies]
   parallel = [ "bsb-core[parallel]" ]
-  neuron = [ "bsb-neuron~=6.0" ]
-  nest = [ "bsb-nest~=6.0" ]
-  arbor = [ "bsb-arbor~=6.0" ]
+  neuron = [ "bsb-neuron~=7.0" ]
+  nest = [ "bsb-nest~=7.0" ]
+  arbor = [ "bsb-arbor~=7.0" ]
 
   [project.urls]
   Home = "https://github.com/dbbs-lab/bsb"
@@ -56,7 +56,7 @@ docs = [
   "furo~=2024.0",
   "sphinxemoji~=0.3",
   "sphinx-copybutton~=0.5",
-  "sphinxext-bsb~=6.0"
+  "sphinxext-bsb~=7.0"
 ]
 
 [tool.uv]


### PR DESCRIPTION
## Describe the work done

Bump versions of bsb so that they use the new major version



<!-- readthedocs-preview bsb-test start -->
----
📚 Documentation preview 📚: https://bsb-test--195.org.readthedocs.build/en/195/

<!-- readthedocs-preview bsb-test end -->

<!-- readthedocs-preview bsb-json start -->
----
📚 Documentation preview 📚: https://bsb-json--195.org.readthedocs.build/en/195/

<!-- readthedocs-preview bsb-json end -->

<!-- readthedocs-preview bsb-core start -->
----
📚 Documentation preview 📚: https://bsb-core--195.org.readthedocs.build/en/195/

<!-- readthedocs-preview bsb-core end -->

<!-- readthedocs-preview bsb-yaml start -->
----
📚 Documentation preview 📚: https://bsb-yaml--195.org.readthedocs.build/en/195/

<!-- readthedocs-preview bsb-yaml end -->

<!-- readthedocs-preview bsb-arbor start -->
----
📚 Documentation preview 📚: https://bsb-arbor--195.org.readthedocs.build/en/195/

<!-- readthedocs-preview bsb-arbor end -->

<!-- readthedocs-preview bsb-neuron start -->
----
📚 Documentation preview 📚: https://bsb-neuron--195.org.readthedocs.build/en/195/

<!-- readthedocs-preview bsb-neuron end -->