### PR TITLE
fix: Caching morphology loaders during placement

### DIFF
--- a/packages/bsb-core/bsb/core.py
+++ b/packages/bsb-core/bsb/core.py
@@ -121,7 +121,7 @@ class Scaffold:
         :returns: A network object
         :rtype: :class:`~.core.Scaffold`
         """
-        self._pool_cache: dict[int, typing.Callable[[], None]] = {}
+        self._pool_cache: dict[int, list[typing.Callable[[], None]]] = {}
         self._pool_listeners: list[tuple[typing.Callable[[list[Job]], None], float]] = []
         self._configuration = None
         self._storage = None
@@ -856,9 +856,9 @@ class Scaffold:
         :param id: Id of the cached item. Should be unique but identical across MPI nodes
         :param cleanup: A callable that cleans up the cached item.
         """
-        if id in self._pool_cache:
-            raise RuntimeError(f"Pool cache item '{id}' already exists.")
-        self._pool_cache[id] = cleanup
+        if id not in self._pool_cache:
+            self._pool_cache[id] = []
+        self._pool_cache[id].append(cleanup)
 
 
 class ReportListener:

--- a/packages/bsb-core/bsb/placement/strategy.py
+++ b/packages/bsb-core/bsb/placement/strategy.py
@@ -11,6 +11,7 @@ from ..config._attrs import cfgdict
 from ..exceptions import DistributorError, EmptySelectionError
 from ..mixins import HasDependencies
 from ..reporting import warn
+from ..services import pool_cache
 from ..storage._chunks import Chunk
 from ..voxels import VoxelSet
 from .distributor import DistributorsNode
@@ -136,6 +137,7 @@ class PlacementStrategy(abc.ABC, HasDependencies):
     def is_entities(self):
         return "entities" in self.__class__.__dict__ and self.__class__.entities
 
+    @pool_cache
     def get_indicators(self):
         """
         Return indicators per cell type.

--- a/packages/bsb-core/bsb/services/pool.py
+++ b/packages/bsb-core/bsb/services/pool.py
@@ -952,10 +952,14 @@ class JobPool:
 
 
 def get_node_cache_items(node):
+    from ..config import walk_nodes
+
     return [
-        attr.get_pool_cache_id(node)
-        for key in dir(node)
-        if hasattr(attr := getattr(node, key), "get_pool_cache_id")
+        attr.get_pool_cache_id(subnode)
+        for subnode in walk_nodes(node)
+        for key in dir(subnode)
+        if hasattr(subnode, key)
+        and hasattr(attr := getattr(subnode, key), "get_pool_cache_id")
     ]
 
 

--- a/packages/bsb-core/bsb/services/pool.py
+++ b/packages/bsb-core/bsb/services/pool.py
@@ -965,8 +965,9 @@ def get_node_cache_items(node):
 
 def free_stale_pool_cache(scaffold, required_cache_items: set[int]):
     for stale_key in set(scaffold._pool_cache.keys()) - required_cache_items:
-        # If so, pop them and execute the registered cleanup function.
-        scaffold._pool_cache.pop(stale_key)()
+        # If so, pop them and execute the registered cleanup functions.
+        for cleanup in scaffold._pool_cache.pop(stale_key):
+            cleanup()
 
 
 def pool_cache(caching_function):


### PR DESCRIPTION
## Description

When running placement strategy jobs, the user can use a distributor to generate morphologies on the fly, this will make the loading of the morphologies performed by each job longer the more morphologies are generated and stored.
The `pool_cache` decorator used to cache node properties across jobs of the same strategy does not work on the nodes stored as sub-class attributes.  

## Work achieved

- Cache the morphology loaders across similar placement strategy jobs.
- Fix `pool_cache` decorator to work with strategy node attributes (by visiting sub classes)

## List which issues this resolves:

Close #201 #202


<!-- readthedocs-preview bsb-core start -->
----
📚 Documentation preview 📚: https://bsb-core--208.org.readthedocs.build/en/208/

<!-- readthedocs-preview bsb-core end -->