### PR TITLE
fix: Replace MPI barrier with an error collection system

### DIFF
--- a/packages/bsb-core/README.md
+++ b/packages/bsb-core/README.md
@@ -1,7 +1,6 @@
 [![Build Status](https://github.com/dbbs-lab/bsb/actions/workflows/main.yml/badge.svg)](https://github.com/dbbs-lab/bsb/actions/workflows/main.yml)
 [![Documentation](https://readthedocs.org/projects/bsb-core/badge/?version=latest)](https://bsb-core.readthedocs.io/en/latest/?badge=latest)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
-[![codecov](https://codecov.io/gh/dbbs-lab/bsb-core/branch/main/graph/badge.svg)](https://codecov.io/gh/dbbs-lab/bsb-core)
 
 # bsb-core
 

--- a/packages/bsb-core/bsb/config/_attrs.py
+++ b/packages/bsb-core/bsb/config/_attrs.py
@@ -473,7 +473,7 @@ def _boot_nodes(top_node, scaffold):
                     boot(node, scaffold)
                     booted.add(boot)
         # Boot node hook
-        with scaffold._comm.try_all(BootError("Boot failed on other process.")):
+        with scaffold._comm.try_all(BootError("Boot failed on different rank.")):
             try:
                 run_hook(node, "boot")
             except Exception as e:

--- a/packages/bsb-core/bsb/config/_attrs.py
+++ b/packages/bsb-core/bsb/config/_attrs.py
@@ -489,13 +489,13 @@ def _boot_nodes(top_node, scaffold):
 
 def _unset_nodes(top_node):
     for node in walk_nodes(top_node):
+        run_hook(node, "unboot")
         with contextlib.suppress(Exception):
             del node.scaffold
         node._config_parent = None
         node._config_key = None
         if hasattr(node, "_config_index"):
             node._config_index = None
-        run_hook(node, "unboot")
 
 
 class ConfigurationAttribute:

--- a/packages/bsb-core/bsb/morphologies/selector.py
+++ b/packages/bsb-core/bsb/morphologies/selector.py
@@ -88,18 +88,15 @@ class NeuroMorphoSelector(NameSelector, classmap_entry="from_neuromorpho"):
     _files = "dableFiles/"
 
     def __boot__(self):
-        fail_to_boot = False
-        if self.scaffold.is_main_process():
-            try:
-                morphos = self._scrape_nm(self.names)
-            except Exception:
-                fail_to_boot = True
-            else:
-                for name, morpho in morphos.items():
-                    self.scaffold.morphologies.save(name, morpho, overwrite=True)
-        self.scaffold._comm.bcast(fail_to_boot)
-        if fail_to_boot:
-            raise
+        with self.scaffold._comm.try_main():
+            if self.scaffold.is_main_process():
+                try:
+                    morphos = self._scrape_nm(self.names)
+                except Exception:
+                    raise
+                else:
+                    for name, morpho in morphos.items():
+                        self.scaffold.morphologies.save(name, morpho, overwrite=True)
 
     def __unboot__(self):
         if self.scaffold.is_main_process():

--- a/packages/bsb-core/bsb/services/mpi.py
+++ b/packages/bsb-core/bsb/services/mpi.py
@@ -93,14 +93,14 @@ class MPIService:
             yield
         except Exception as e:
             exc_instance = e
-        finally:
-            exceptions = self.allgather(exc_instance)
-            if any(exceptions):
-                raise (
-                    exceptions[self.get_rank()]
-                    if exceptions[self.get_rank()]
-                    else default_exception
-                )
+
+        exceptions = self.allgather(exc_instance)
+        if any(exceptions):
+            raise (
+                exceptions[self.get_rank()]
+                if exceptions[self.get_rank()]
+                else default_exception
+            )
 
     @contextlib.contextmanager
     def try_main(self):
@@ -120,10 +120,10 @@ class MPIService:
             yield
         except Exception as e:
             exc_instance = e
-        finally:
-            exception = self.bcast(exc_instance)
-            if exception is not None:
-                raise exception
+
+        exception = self.bcast(exc_instance)
+        if exception is not None:
+            raise exception
 
 
 class MPIModule(MockModule):

--- a/packages/bsb-core/tests/test_selectors.py
+++ b/packages/bsb-core/tests/test_selectors.py
@@ -1,6 +1,6 @@
 import unittest
 
-from bsb_test import RandomStorageFixture, skip_parallel, skipIfOffline
+from bsb_test import RandomStorageFixture, skipIfOffline
 
 from bsb import (
     MPI,
@@ -105,7 +105,6 @@ class TestSelectors(RandomStorageFixture, unittest.TestCase, engine_name="hdf5")
         m = s.morphologies.select(*ct.spatial.morphologies)[0]
         self.assertEqual(name, m.get_meta()["neuron_name"], "meta not stored")
 
-    @skip_parallel  # https://github.com/dbbs-lab/bsb/issues/187
     @skipIfOffline(scheme=NeuroMorphoScheme())
     def test_nm_selector_wrong_name(self):
         ct = CellType(

--- a/packages/bsb-core/tests/test_util.py
+++ b/packages/bsb-core/tests/test_util.py
@@ -5,7 +5,6 @@ from bsb_test import (
     FixedPosConfigFixture,
     NumpyTestCase,
     RandomStorageFixture,
-    skip_parallel,
     skipIfOffline,
 )
 from scipy.spatial.transform import Rotation
@@ -70,7 +69,6 @@ class TestRotationUtils(unittest.TestCase):
 
 
 class TestUriSchemes(RandomStorageFixture, unittest.TestCase, engine_name="fs"):
-    @skip_parallel  # see https://github.com/dbbs-lab/bsb/issues/197
     @skipIfOffline(scheme=NeuroMorphoScheme())
     def test_nm_scheme(self):
         file = FileDependency(


### PR DESCRIPTION
## Describe the work done
- During boot, functions loading files may get stuck in parallel as one of the process is throwing an error but the others remain stuck at a `MPI.Barrier()`. Instead, this PR replaces the barrier with a status collector at the end of these functions to make sure each process is aware if one its fellow process is failing and raises an exception accordingly. 
- Morphologies collected from NeuroMorpho  will now be removed from the Scaffold if the `NeuroMorphoSelector` node is unset (through the `__unboot__` function)

## List which issues this resolves:
Fix #211, #197, #187

## Tasks

* [x] Added tests


<!-- readthedocs-preview bsb-core start -->
----
📚 Documentation preview 📚: https://bsb-core--212.org.readthedocs.build/en/212/

<!-- readthedocs-preview bsb-core end -->