### PR TITLE
fix: bump mpi4py and minor fixes

### DIFF
--- a/devtools/install-nest.sh
+++ b/devtools/install-nest.sh
@@ -7,7 +7,7 @@ fi
 if [ -z "$NEST_VERSION" ]; then NEST_VERSION="3.7"; fi
 
 # Trying to load NEST
-INSTALLATION_FOLDER="$NEST_FOLDER/install/"
+INSTALLATION_FOLDER="$NEST_FOLDER/install"
 if [ -f "$INSTALLATION_FOLDER/bin/nest_vars.sh" ]; then
   . "$INSTALLATION_FOLDER/bin/nest_vars.sh"
 fi
@@ -21,7 +21,7 @@ while [ -f "$LOCK_FILE" ]; do sleep 1; done
 touch "$LOCK_FILE"
 
 # Check if NEST has been already installed
-if [ "$(which nest)" != "" ];  then
+if [ "$(which nest)" == "$INSTALLATION_FOLDER/bin/nest" ];  then
   INSTALLED_VERSION=$(echo $(nest --version) | grep -o -E 'version [0-9.]+' | sed 's/version //')
   if [ "$INSTALLED_VERSION" == "$NEST_VERSION.0" ] || [ "$INSTALLED_VERSION" == "$NEST_VERSION" ]; then
     echo "NEST already installed.";

--- a/packages/bsb-core/bsb/morphologies/__init__.py
+++ b/packages/bsb-core/bsb/morphologies/__init__.py
@@ -285,7 +285,7 @@ class RotationSet:
         return self._rot(angles)
 
     def _rot(self, angles):
-        return Rotation.from_euler("xyz", angles)
+        return Rotation.from_euler("xyz", angles, degrees=True)
 
 
 def branch_iter(branch):

--- a/packages/bsb-core/bsb/storage/_files.py
+++ b/packages/bsb-core/bsb/storage/_files.py
@@ -150,10 +150,6 @@ class FileDependency:
         )
 
     def should_update(self):
-        if not self.file_store:
-            raise ValueError(
-                "Can't update file dependency in store before scaffold is ready."
-            )
         stored = self.get_stored_file()
         return stored is None or self._scheme.should_update(self, stored)
 

--- a/packages/bsb-core/pyproject.toml
+++ b/packages/bsb-core/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
   file = "LICENSE"
 
   [project.optional-dependencies]
-  parallel = [ "mpi4py~=3.0", "mpipool>=2.2.1,<3", "mpilock~=1.1" ]
+  parallel = [ "mpi4py~=4.1.0", "mpipool>=2.2.1,<3", "mpilock~=1.1" ]
 
 [project.entry-points."bsb.storage.engines"]
 fs = "bsb.storage.fs"

--- a/packages/bsb-core/tests/test_distributors.py
+++ b/packages/bsb-core/tests/test_distributors.py
@@ -153,7 +153,12 @@ class TestVolumetricRotations(
         region_ids = np.asarray(
             voxel_set.data[:, 0][voxel_set.index_of(positions)], dtype=int
         )
-        rotations = np.array(self.network.get_placement_set("a").load_rotations())
+        rotations = self.network.get_placement_set("a").load_rotations()
+        rotations2 = np.array(
+            [rot.as_euler("xyz", degrees=True) for rot in rotations.iter()]
+        )
+        rotations = np.array(rotations)
+        self.assertTrue(np.allclose(rotations, rotations2), "Regression for issue #220")
         # Regions without orientation field -> no rotation
         self.assertTrue(
             np.array_equal(

--- a/packages/bsb-nest/bsb_nest/adapter.py
+++ b/packages/bsb-nest/bsb_nest/adapter.py
@@ -192,12 +192,9 @@ class NestAdapter(SimulatorAdapter):
         nest.set_verbosity(simulation.verbosity)
         nest.resolution = simulation.resolution
         nest.overwrite_files = True
+        # When simulating with MUSIC the following line might cause issue.
+        # Set the MPI communicator for NEST manually in your script once
+        # the NESTAdapter has been prepared.
+        nest.set_communicator(self.comm._comm)
         if simulation.seed is not None:
             nest.rng_seed = simulation.seed
-
-    def check_comm(self):
-        if nest.NumProcesses() != self.comm.get_size():
-            raise RuntimeError(
-                f"NEST is managing {nest.NumProcesses()} processes, but "
-                f"{self.comm.get_size()} were detected. Please check your MPI setup."
-            )

--- a/packages/bsb-nest/bsb_nest/adapter.py
+++ b/packages/bsb-nest/bsb_nest/adapter.py
@@ -195,6 +195,6 @@ class NestAdapter(SimulatorAdapter):
         # When simulating with MUSIC the following line might cause issue.
         # Set the MPI communicator for NEST manually in your script once
         # the NESTAdapter has been prepared.
-        nest.set_communicator(self.comm._comm)
+        nest.set_communicator.__func__(self.comm._comm)
         if simulation.seed is not None:
             nest.rng_seed = simulation.seed

--- a/packages/bsb-nest/bsb_nest/adapter.py
+++ b/packages/bsb-nest/bsb_nest/adapter.py
@@ -195,6 +195,7 @@ class NestAdapter(SimulatorAdapter):
         # When simulating with MUSIC the following line might cause issue.
         # Set the MPI communicator for NEST manually in your script once
         # the NESTAdapter has been prepared.
-        nest.set_communicator.__func__(self.comm._comm)
+        if "mpi4py" in sys.modules:
+            nest.set_communicator.__func__(self.comm._comm)
         if simulation.seed is not None:
             nest.rng_seed = simulation.seed

--- a/packages/bsb/docs/dev/faq.rst
+++ b/packages/bsb/docs/dev/faq.rst
@@ -71,7 +71,7 @@ FAQ
         adapter.reset_kernel()
         simulation_backend = adapter.prepare(simulation)
         # Set NEST communicator here
-        nest.set_communicator(comm_nest)
+        nest.set_communicator.__func__(comm_nest)
         # rest of your code here.
 
 .. dropdown:: When do I need to recompile my Scaffold?

--- a/packages/bsb/docs/dev/faq.rst
+++ b/packages/bsb/docs/dev/faq.rst
@@ -43,6 +43,37 @@ FAQ
 
         # rest of your code here.
 
+    .. rubric:: Advanced MPI options
+
+    Note that if you manually create the MPI communicator with a subgroup of cores available
+    and pass it to your BSB Scaffold, it will also set the MPI communicator for NEST.
+    If you need a different MPI communicator between NEST and BSB, you should set it manually once the `NESTAdapter` has been prepared
+    (see also this :doc:`BSB-NEST example</examples/nest_repeated_sim>`):
+
+    .. code-block:: python
+
+        import nest
+        from mpi4py import MPI
+        from bsb import from_storage
+        from bsb_nest import NestAdapter
+
+        # We take all cores for NEST
+        comm_nest = MPI.COMM_WORLD
+
+        # We do not take the last core for BSB
+        comm_bsb = MPI.COMM_WORLD.Create_group(
+            MPI.COMM_WORLD.group.Excl([MPI.COMM_WORLD.Get_size() - 1])
+        )
+
+        scaffold = from_storage("network.hdf5", comm=comm_bsb)
+        simulation = scaffold.get_simulation("basal_activity")
+        adapter = NestAdapter()
+        adapter.reset_kernel()
+        simulation_backend = adapter.prepare(simulation)
+        # Set NEST communicator here
+        nest.set_communicator(comm_nest)
+        # rest of your code here.
+
 .. dropdown:: When do I need to recompile my Scaffold?
     :animate: fade-in-slide-down
 


### PR DESCRIPTION
## Describe the work done
- Bump mpi4py version to latest version
- Forward MPI communicator to NEST during simulations
- Fix RotationSet iterator

## List which issues this resolves:

closes #220, #216

## Tasks

* [x] Added tests
* [x] Updated documentation


<!-- readthedocs-preview bsb-nest start -->
----
📚 Documentation preview 📚: https://bsb-nest--221.org.readthedocs.build/en/221/

<!-- readthedocs-preview bsb-nest end -->

<!-- readthedocs-preview bsb start -->
----
📚 Documentation preview 📚: https://bsb--221.org.readthedocs.build/en/221/

<!-- readthedocs-preview bsb end -->

<!-- readthedocs-preview bsb-core start -->
----
📚 Documentation preview 📚: https://bsb-core--221.org.readthedocs.build/en/221/

<!-- readthedocs-preview bsb-core end -->