### PR TITLE
fix: Loading modules to check NEST models

### DIFF
--- a/examples/writing-components/writing_components/distrib_placement.py
+++ b/examples/writing-components/writing_components/distrib_placement.py
@@ -59,7 +59,7 @@ class DistributionPlacement(PlacementStrategy, classmap_entry="distrib_placement
             # For each partitions
             for p in indicator.partitions:
                 # Guess the number of cells to place within the partition.
-                num_to_place = indicator.guess(voxels=p.to_voxels())
+                num_to_place = np.sum(indicator.guess(voxels=p.to_voxels()))
                 # Extract the size of the partition
                 partition_size = p._data.mdc - p._data.ldc
                 # Retrieve the ratio interval occupied by the current Chunk along the axis

--- a/packages/bsb-arbor/bsb_arbor/adapter.py
+++ b/packages/bsb-arbor/bsb_arbor/adapter.py
@@ -385,7 +385,7 @@ class ArborAdapter(SimulatorAdapter):
             if self.comm.get_size() > 1:
                 if not arbor.config()["mpi4py"]:
                     warn(
-                        f"Arbor does not seem to be built with MPI support, running"
+                        f"Arbor does not seem to be built with MPI support, running "
                         f"duplicate simulations on {self.comm.get_size()} nodes."
                     )
                 else:

--- a/packages/bsb-core/bsb/config/_make.py
+++ b/packages/bsb-core/bsb/config/_make.py
@@ -647,7 +647,7 @@ def walk_node_attributes(node):
 
 def walk_nodes(node):
     """
-    Walk over all of the child configuration nodes of ``node``.
+    Walk over all the child configuration nodes of ``node``.
 
     :returns: node generator
     :rtype: Any

--- a/packages/bsb-core/bsb/placement/indicator.py
+++ b/packages/bsb-core/bsb/placement/indicator.py
@@ -96,11 +96,11 @@ class PlacementIndicator:
         count_ratio = self.indication("count_ratio")
         local_count_ratio = self.indication("local_count_ratio")
         if count is not None:
-            estimate = self._estim_for_chunk(chunk, count)
+            estimate = [self._estim_for_chunk(chunk, count)]
         if density is not None:
-            estimate = self._density_to_estim(density, chunk)
+            estimate = [self._density_to_estim(density, chunk)]
         if planar_density is not None:
-            estimate = self._pdensity_to_estim(planar_density, chunk)
+            estimate = [self._pdensity_to_estim(planar_density, chunk)]
         if relative_to is not None:
             relation = relative_to
             if count_ratio is not None:
@@ -109,22 +109,24 @@ class PlacementIndicator:
                 # This number is uniformly distributed across the current
                 # strategy's partition(s).
                 strats = self._strat.scaffold.get_placement_of(relation)
-                estimate = self._estim_for_chunk(
-                    chunk,
-                    sum(PlacementIndicator(s, relation).guess() for s in strats)
-                    * count_ratio,
-                )
+                estimate = [
+                    self._estim_for_chunk(
+                        chunk,
+                        sum(PlacementIndicator(s, relation).guess() for s in strats)
+                        * count_ratio,
+                    )
+                ]
             elif local_count_ratio is not None:
                 # This count estimate is the ratio of the number of cell of the
                 # target strategy that were placed in the current chunk.
                 strats = self._strat.scaffold.get_placement_of(relation)
-                estimate = (
+                estimate = [
                     sum(
                         PlacementIndicator(s, relation).guess(chunk, voxels)
                         for s in strats
                     )
                     * local_count_ratio
-                )
+                ]
             elif density_ratio is not None:
                 # Create an indicator based on this strategy for the related CT.
                 # This means we'll read only the CT indications, and ignore any
@@ -135,11 +137,13 @@ class PlacementIndicator:
                 rel_pl_density = rel_ind.indication("planar_density")
                 rel_pl_density_key = rel_ind.indication("density_key")
                 if rel_density is not None:
-                    estimate = self._density_to_estim(rel_density * density_ratio, chunk)
+                    estimate = [
+                        self._density_to_estim(rel_density * density_ratio, chunk)
+                    ]
                 elif rel_pl_density is not None:
-                    estimate = self._pdensity_to_estim(
-                        rel_pl_density * density_ratio, chunk
-                    )
+                    estimate = [
+                        self._pdensity_to_estim(rel_pl_density * density_ratio, chunk)
+                    ]
                 elif rel_pl_density_key is not None:
                     # Use the relation's `guess` to guess according to the relation's
                     # density key
@@ -161,6 +165,7 @@ class PlacementIndicator:
                         estimate += np.sum(
                             self._estim_for_voxels(p.to_voxels(), density_key)
                         )
+                        estimate = [estimate]
                     except IndexError as _:
                         raise PlacementError(
                             f"Partition {p} voxelset does not have "

--- a/packages/bsb-core/bsb/placement/random.py
+++ b/packages/bsb-core/bsb/placement/random.py
@@ -180,6 +180,7 @@ class VolumeFiller:
         for particle_type in self.particle_types:
             count = particle_type["count"]
             if count.size == 1:
+                particle_type["count"] = particle_type["count"][0]
                 self._fill_global(particle_type)
             else:
                 self._fill_per_voxel(particle_type)
@@ -200,7 +201,7 @@ class VolumeFiller:
                 self.add_particle(radius, particle_position, type=particle_type)
 
     def _fill_global(self, particle_type):
-        particle_count = int(particle_type["count"][0])
+        particle_count = int(particle_type["count"])
         particle_type["placed"] = particle_type.get("placed", 0) + particle_count
         radius = particle_type["radius"]
         # Generate a matrix with random positions for the particles

--- a/packages/bsb-core/bsb/placement/random.py
+++ b/packages/bsb-core/bsb/placement/random.py
@@ -200,7 +200,7 @@ class VolumeFiller:
                 self.add_particle(radius, particle_position, type=particle_type)
 
     def _fill_global(self, particle_type):
-        particle_count = int(particle_type["count"])
+        particle_count = int(particle_type["count"][0])
         particle_type["placed"] = particle_type.get("placed", 0) + particle_count
         radius = particle_type["radius"]
         # Generate a matrix with random positions for the particles

--- a/packages/bsb-core/tests/test_geometric_shapes.py
+++ b/packages/bsb-core/tests/test_geometric_shapes.py
@@ -452,8 +452,8 @@ class TestGeometricShapes(unittest.TestCase, NumpyTestCase):
         self.assertClose(mbb[1], expected_mbb[1])
         wireframe = np.array(sc.generate_wireframe())
         self.assertEqual((3, 1, 4, 4), wireframe.shape)
-        self.assertTrue(np.alltrue(wireframe.reshape(3, 16).T - expected_mbb[0] >= -1e-5))
-        self.assertTrue(np.alltrue(wireframe.reshape(3, 16).T - expected_mbb[1] <= 1e-5))
+        self.assertTrue(np.all(wireframe.reshape(3, 16).T - expected_mbb[0] >= -1e-5))
+        self.assertTrue(np.all(wireframe.reshape(3, 16).T - expected_mbb[1] <= 1e-5))
 
     # Create a cuboid, add it to a ShapeComposition object and test the minimal bounding
     # box, inside_mbox, inside_shapes and generate_point_cloud methods
@@ -545,8 +545,8 @@ class TestGeometricShapes(unittest.TestCase, NumpyTestCase):
         self.assertClose(mbb[1], expected_mbb[1])
         wireframe = np.array(sc.generate_wireframe())
         self.assertEqual((3, 1, 4, 4), wireframe.shape)
-        self.assertTrue(np.alltrue(wireframe.reshape(3, 16).T - expected_mbb[0] >= -1e-5))
-        self.assertTrue(np.alltrue(wireframe.reshape(3, 16).T - expected_mbb[1] <= 1e-5))
+        self.assertTrue(np.all(wireframe.reshape(3, 16).T - expected_mbb[0] >= -1e-5))
+        self.assertTrue(np.all(wireframe.reshape(3, 16).T - expected_mbb[1] <= 1e-5))
 
     # Create a cone, add it to a ShapeComposition object and test the minimal bounding box
     # inside_mbox, inside_shapes and generate_point_cloud methods
@@ -643,7 +643,7 @@ class TestGeometricShapes(unittest.TestCase, NumpyTestCase):
         wireframe = np.array(sc.generate_wireframe())
         self.assertEqual((3, 1, 30, 30), wireframe.shape)
         self.assertTrue(
-            np.alltrue(
+            np.all(
                 np.linalg.norm(
                     (wireframe[:, 0, :, 0] - cone.origin[..., np.newaxis])[
                         np.array([0, 1])

--- a/packages/bsb-nest/bsb_nest/cell.py
+++ b/packages/bsb-nest/bsb_nest/cell.py
@@ -1,5 +1,5 @@
 import nest
-from bsb import CellModel, config
+from bsb import CellModel, ConfigurationError, config
 
 from .distributions import NestRandomDistribution, nest_parameter
 
@@ -10,6 +10,12 @@ class NestCell(CellModel):
     """Importable reference to the NEST model describing the cell type."""
     constants = config.dict(type=nest_parameter())
     """Dictionary of the constants values to assign to the cell model."""
+
+    def __boot__(self):
+        import nest
+
+        if self.model not in nest.Models(mtype="nodes"):
+            raise ConfigurationError(f"Unknown cell model '{self.model}'.")
 
     def create_population(self, simdata):
         n = len(simdata.placement[self])

--- a/packages/bsb-nest/bsb_nest/connection.py
+++ b/packages/bsb-nest/bsb_nest/connection.py
@@ -1,21 +1,12 @@
 import functools
 import sys
 
-import nest
 import numpy as np
 import psutil
 from bsb import ConfigurationError, ConnectionModel, compose_nodes, config, options, types
 from tqdm import tqdm
 
 from .distributions import nest_parameter
-
-
-def _is_delay_required(node):
-    model = node.get("model", NestSynapseSettings.model.default)
-    if model not in nest.Models(mtype="synapses"):
-        raise ConfigurationError(f"Unknown synapse model '{model}'.")
-    else:
-        return nest.GetDefaults(model)["has_delay"]
 
 
 @config.node
@@ -28,12 +19,20 @@ class NestSynapseSettings:
     """Importable reference to the NEST model describing the synapse type."""
     weight = config.attr(type=float, required=True)
     """Weight of the connection between the presynaptic and the postsynaptic cells."""
-    delay = config.attr(type=float, required=_is_delay_required, default=None)
+    delay = config.attr(type=float, default=None)
     """Delay of the transmission between the presynaptic and the postsynaptic cells."""
     receptor_type = config.attr(type=int)
     """Index of the postsynaptic receptor to target."""
     constants = config.catch_all(type=nest_parameter())
     """Dictionary of the constants values to assign to the synapse model."""
+
+    def __boot__(self):
+        import nest
+
+        if self.model not in nest.Models(mtype="synapses"):
+            raise ConfigurationError(f"Unknown synapse model '{self.model}'.")
+        if nest.GetDefaults(self.model)["has_delay"] and self.delay is None:
+            raise ConfigurationError("Synapse model requires 'delay' to be set.")
 
 
 @config.node
@@ -67,6 +66,8 @@ class LazySynapseCollection:
 
     @functools.cached_property
     def collection(self):
+        import nest
+
         return nest.GetConnections(self._pre, self._post)
 
 

--- a/packages/bsb-nest/bsb_nest/simulation.py
+++ b/packages/bsb-nest/bsb_nest/simulation.py
@@ -46,10 +46,7 @@ class NestSimulation(Simulation):
             except Exception as e:
                 if e.errorname == "DynamicModuleManagementError":
                     if "loaded already" in e.message:
-                        pass
+                        continue
                     elif "file not found" in e.message:
                         raise NestModuleError(f"Module {module} not found") from None
-                    else:  # pragma: nocover
-                        raise
-                else:  # pragma: nocover
-                    raise
+                raise  # pragma: nocover

--- a/packages/bsb-nest/bsb_nest/simulation.py
+++ b/packages/bsb-nest/bsb_nest/simulation.py
@@ -49,7 +49,7 @@ class NestSimulation(Simulation):
                         pass
                     elif "file not found" in e.message:
                         raise NestModuleError(f"Module {module} not found") from None
-                    else:
+                    else:  # pragma: nocover
                         raise
-                else:
+                else:  # pragma: nocover
                     raise

--- a/packages/bsb-nest/bsb_nest/simulation.py
+++ b/packages/bsb-nest/bsb_nest/simulation.py
@@ -34,3 +34,22 @@ class NestSimulation(Simulation):
         type=NestDevice, required=True
     )
     """Dictionary of devices in the simulation."""
+
+    def __boot__(self):
+        import nest
+
+        from .exceptions import NestModuleError
+
+        for module in self.modules:
+            try:
+                nest.Install(module)
+            except Exception as e:
+                if e.errorname == "DynamicModuleManagementError":
+                    if "loaded already" in e.message:
+                        pass
+                    elif "file not found" in e.message:
+                        raise NestModuleError(f"Module {module} not found") from None
+                    else:
+                        raise
+                else:
+                    raise

--- a/packages/bsb-nest/tests/test_nest.py
+++ b/packages/bsb-nest/tests/test_nest.py
@@ -827,7 +827,7 @@ class TestNest(
         duration = 100
         resolution = 0.1
         cfg = _conf_two_cells()
-        with self.assertRaises(CastError):
+        with self.assertRaises(BootError):
             cfg.simulations = {
                 "test": {
                     "simulator": "nest",
@@ -848,6 +848,7 @@ class TestNest(
                     "devices": {},
                 }
             }
+            _ = Scaffold(cfg, self.storage)
 
     def test_gap_junctions_syn(self):
         duration = 100
@@ -881,7 +882,7 @@ class TestNest(
         duration = 100
         resolution = 0.1
         cfg = _conf_two_cells()
-        with self.assertRaises(ConfigurationError):
+        with self.assertRaises(BootError):
             cfg.simulations = {
                 "test": {
                     "simulator": "nest",
@@ -902,6 +903,7 @@ class TestNest(
                     "devices": {},
                 }
             }
+            _ = Scaffold(cfg, self.storage)
 
     def test_multisyn_collocation(self):
         cfg = _conf_single_cell()

--- a/packages/bsb-nest/tests/test_nest.py
+++ b/packages/bsb-nest/tests/test_nest.py
@@ -823,6 +823,34 @@ class TestNest(
             membrane_potentials[time_effect_sec_syn - 1],
         )
 
+    def test_unknown_modules(self):
+        duration = 100
+        resolution = 0.1
+        cfg = _conf_two_cells()
+        with self.assertRaises(BootError):
+            cfg.simulations = {
+                "test": {
+                    "simulator": "nest",
+                    "duration": duration,
+                    "resolution": resolution,
+                    "modules": ["bla"],
+                    "seed": 1234,
+                    "cell_models": {
+                        "A": {"model": "iaf_cond_alpha"},
+                        "C": {"model": "parrot_neuron"},
+                    },
+                    "connection_models": {
+                        "C_to_A": {
+                            "synapses": [
+                                {"model": "static_synapse", "weight": -20.25, "delay": 1},
+                            ],
+                        }
+                    },
+                    "devices": {},
+                }
+            }
+            _ = Scaffold(cfg, self.storage)
+
     def test_unknown_synapse(self):
         duration = 100
         resolution = 0.1

--- a/packages/bsb-nest/tests/test_nest.py
+++ b/packages/bsb-nest/tests/test_nest.py
@@ -850,6 +850,33 @@ class TestNest(
             }
             _ = Scaffold(cfg, self.storage)
 
+    def test_unknown_cell(self):
+        duration = 100
+        resolution = 0.1
+        cfg = _conf_two_cells()
+        with self.assertRaises(BootError):
+            cfg.simulations = {
+                "test": {
+                    "simulator": "nest",
+                    "duration": duration,
+                    "resolution": resolution,
+                    "seed": 1234,
+                    "cell_models": {
+                        "A": {"model": "bla_bla"},
+                        "C": {"model": "parrot_neuron"},
+                    },
+                    "connection_models": {
+                        "C_to_A": {
+                            "synapses": [
+                                {"model": "static_synapse", "weight": -20.25, "delay": 1},
+                            ],
+                        }
+                    },
+                    "devices": {},
+                }
+            }
+            _ = Scaffold(cfg, self.storage)
+
     def test_gap_junctions_syn(self):
         duration = 100
         resolution = 0.1


### PR DESCRIPTION
## Describe the work done
- Implementation of a temporary solution to check for NEST models provided in Configuration before implementing the refactor discussed here: #227
- Make indicator.guess actually return a numpy array in every case 
- Remove a couple of warnings

Not sure how to test NEST modules

## List which issues this resolves:

closes #226 

## Tasks

* [x] Added tests


<!-- readthedocs-preview bsb-core start -->
----
📚 Documentation preview 📚: https://bsb-core--228.org.readthedocs.build/en/228/

<!-- readthedocs-preview bsb-core end -->

<!-- readthedocs-preview bsb-nest start -->
----
📚 Documentation preview 📚: https://bsb-nest--228.org.readthedocs.build/en/228/

<!-- readthedocs-preview bsb-nest end -->

<!-- readthedocs-preview bsb-arbor start -->
----
📚 Documentation preview 📚: https://bsb-arbor--228.org.readthedocs.build/en/228/

<!-- readthedocs-preview bsb-arbor end -->