### PR TITLE
test(bsb-otel): make parallel telemetry tests self-sufficient

### DIFF
--- a/packages/bsb-core/tests/test_observability.py
+++ b/packages/bsb-core/tests/test_observability.py
@@ -8,7 +8,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from bsb_otel.testing import OTelFixture
+from bsb_otel.testing import OTelFixture, broadcast_root, detached_span
 from bsb_otel.tracer import get_bsb_tracer
 
 from bsb import MPI, handle_command
@@ -112,26 +112,21 @@ class TestTelemetryCliCommand(unittest.TestCase):
         """
         Tests whether traces are collected for a normal CLI command.
         """
-        from opentelemetry import context as otel_context
-        from opentelemetry.trace import INVALID_SPAN, set_span_in_context
-
         # Detach the test wrapper's parent span so handle_command's internal
         # BsbTracer.trace("cli") takes the no-parent broadcast branch
         # (rank 0 records, non-root gets a NonRecordingSpan).  Without this
         # the cli span becomes a child of the wrap span and is recorded on
-        # every rank.
-        _token = otel_context.attach(set_span_in_context(INVALID_SPAN))
-        try:
-            with (
-                # Silence output of --version to stdout
-                open(os.devnull, "w") as devnull,
-                contextlib.redirect_stdout(devnull),
-                # Capture otel output
-                OTelFixture() as results,
-            ):
-                handle_command(["--version"])
-        finally:
-            otel_context.detach(_token)
+        # every rank. The broadcast root here is opened by handle_command, not
+        # by the test, so only the detach is needed.
+        with (
+            detached_span(),
+            # Silence output of --version to stdout
+            open(os.devnull, "w") as devnull,
+            contextlib.redirect_stdout(devnull),
+            # Capture otel output
+            OTelFixture() as results,
+        ):
+            handle_command(["--version"])
 
         spans = results()
         if MPI.get_rank() == 0:
@@ -153,10 +148,10 @@ class TestTelemetryInterfaces(unittest.TestCase):
         @config.node (or instrumented via _instrument_node directly) are
         automatically wrapped in an OTel span.
         """
-        with OTelFixture() as results:
+        with OTelFixture() as results, broadcast_root(_tracer, "component_root"):
             _ConcreteImpl().compute()
 
-        spans = results()
+        spans = [s for s in results() if s["name"] == "_ConcreteImpl.compute"]
         self.assertEqual(len(spans), 1, "Expected exactly one component-method span")
         span = spans[0]
         self.assertEqual(span["name"], "_ConcreteImpl.compute")
@@ -175,10 +170,16 @@ class TestTelemetryMPI(unittest.TestCase):
         Every span carries the correct mpi.rank and mpi.size for the rank it
         was recorded on.
         """
-        with OTelFixture() as results, _tracer.trace("probe"):
+        with (
+            OTelFixture() as results,
+            broadcast_root(_tracer, "probe_root"),
+            _tracer.trace("probe"),
+        ):
             pass
 
-        my_spans = results()
+        # Rank 0 also records the broadcast root span; keep just the named probe
+        # spans before the per-rank count assertion.
+        my_spans = [s for s in results() if s["name"] == "probe"]
         all_spans = MPI.allgather(my_spans)  # list[list[dict]], one per rank
 
         for rank, rank_spans in enumerate(all_spans):
@@ -207,24 +208,13 @@ class TestTelemetryMPI(unittest.TestCase):
         This verifies the full "back all the way up to the single broadcasted
         root" property.
         """
-        from opentelemetry import context as otel_context
-        from opentelemetry.trace import INVALID_SPAN, set_span_in_context
-
-        # Detach the current span context so ``broadcast_root`` is created
-        # without a parent and BsbTracer.trace takes the broadcast branch.
-        # Outer span (the test wrapper) would otherwise turn broadcast_root
-        # into a plain per-rank child span.
-        token = otel_context.attach(set_span_in_context(INVALID_SPAN))
-        try:
-            with (
-                OTelFixture() as results,
-                _tracer.trace("broadcast_root"),
-                _tracer.trace("rank_child"),
-                _tracer.trace("rank_grandchild"),
-            ):
-                pass
-        finally:
-            otel_context.detach(token)
+        with (
+            OTelFixture() as results,
+            broadcast_root(_tracer, "broadcast_root"),
+            _tracer.trace("rank_child"),
+            _tracer.trace("rank_grandchild"),
+        ):
+            pass
 
         my_spans = results()
         all_spans = MPI.allgather(my_spans)

--- a/packages/bsb-otel/bsb_otel/testing.py
+++ b/packages/bsb-otel/bsb_otel/testing.py
@@ -1,3 +1,4 @@
+import contextlib
 import functools
 import json
 import os
@@ -7,6 +8,48 @@ import unittest
 from collections import deque
 
 from opentelemetry import trace
+
+
+@contextlib.contextmanager
+def detached_span():
+    """
+    Run the enclosed block with no active parent span.
+
+    Attaches an ``INVALID_SPAN`` to the current OpenTelemetry context so that
+    :meth:`bsb_otel.tracer.BsbTracer.trace` sees no valid ambient parent, and
+    detaches it again on exit. Lets parallel telemetry tests exercise the
+    cross-rank broadcast branch without an externally supplied outer span
+    (such as one installed by ``opentelemetry-instrument`` or by the
+    ``load_tests`` wrap span).
+    """
+    from opentelemetry import context as otel_context
+    from opentelemetry.trace import INVALID_SPAN, set_span_in_context
+
+    token = otel_context.attach(set_span_in_context(INVALID_SPAN))
+    try:
+        yield
+    finally:
+        otel_context.detach(token)
+
+
+@contextlib.contextmanager
+def broadcast_root(tracer, name, attributes=None):
+    """
+    Open a broadcast-root span for *tracer* with no ambient parent.
+
+    Runs :func:`detached_span` so that, under MPI, ``tracer.trace(name)`` takes
+    its broadcast-root branch deterministically: rank 0 records the span and
+    broadcasts its context, while the other ranks attach a non-recording copy.
+    Child spans opened inside this block are then recorded on every rank. In
+    serial mode it is just an ordinary span.
+
+    :param bsb_otel.tracer.BsbTracer tracer: tracer used to open the root span
+    :param str name: name of the root span
+    :param dict attributes: OpenTelemetry attributes for the root span
+    :returns: the root span, for use as a context manager.
+    """
+    with detached_span(), tracer.trace(name, attributes=attributes) as span:
+        yield span
 
 
 def _pop(queue):
@@ -267,4 +310,4 @@ class OTelFixture:
         self.temp_file.close()
 
 
-__all__ = ["OTelFixture", "wrap_tests_with_traces"]
+__all__ = ["OTelFixture", "broadcast_root", "detached_span", "wrap_tests_with_traces"]


### PR DESCRIPTION
Fixes #238.

## Problem
`TestTelemetryMPI.test_mpi_rank_size_attributes` and `TestTelemetryInterfaces.test_component_method_traced` failed (`0 != 1` spans on non-root ranks) whenever the suite was not run under `opentelemetry-instrument` (local `nx run`) or a single test was run by name.

## Cause
`BsbTracer.trace` takes its broadcast-root branch when there is no valid active parent span and MPI `size > 1`: rank 0 records and broadcasts the span context, other ranks attach a non-recording copy that never exports. The two tests traced a single operation directly inside `OTelFixture`, so that operation was the outermost span and only rank 0 recorded. CI passed only because `opentelemetry-instrument` plus the `wrap_tests_with_traces` `load_tests` hook supplied a real recording outer span; remove either and the tests failed.

The `local_tracing()` workaround was rejected: it sets `COMM_SELF` so each rank traces independently, removing the cross-rank broadcast the MPI tests exist to assert.

## Fix
Make the tests self-sufficient by opening their own broadcast root inside `OTelFixture` (which already installs a real SDK provider), then asserting on the named child spans. Two reusable helpers in `bsb_otel.testing` centralize the context-detach boilerplate:

- `detached_span()`: run a block with no ambient parent span.
- `broadcast_root(tracer, name, attributes=None)`: `detached_span()` plus a named root span, making `trace` take the broadcast-root branch deterministically.

The four affected tests now use these helpers and filter `results()` by span name so rank 0's extra root span does not break the per-rank count. Real cross-rank broadcast is still exercised.

## Verification
Ran the full matrix (by-name / no-instrument / serial / parallel, plus the with-instrument suite path) under MPI; all pass on every rank. The previously failing tests now pass without `opentelemetry-instrument`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- readthedocs-preview bsb-otel start -->
----
📚 Documentation preview 📚: https://bsb-otel--252.org.readthedocs.build/en/252/

<!-- readthedocs-preview bsb-otel end -->

<!-- readthedocs-preview bsb-core start -->
----
📚 Documentation preview 📚: https://bsb-core--252.org.readthedocs.build/en/252/

<!-- readthedocs-preview bsb-core end -->