### PR TITLE
fix: code dependency config for dotted paths.

### DIFF
--- a/packages/bsb-core/bsb/storage/_files.py
+++ b/packages/bsb-core/bsb/storage/_files.py
@@ -6,6 +6,7 @@ import datetime as _dt
 import email.utils as _eml
 import functools as _ft
 import hashlib as _hl
+import importlib.util
 import os
 import pathlib as _pl
 import tempfile as _tf
@@ -407,6 +408,44 @@ class FileDependencyNode:
         return self.file.get_stored_file()
 
 
+def _looks_like_code_file_path(module: str) -> bool:
+    """
+    Heuristic to tell a filesystem path apart from a dotted Python import string, for
+    :class:`CodeDependencyNode`'s ``module`` field: it's a path if it contains a path
+    separator, or already ends in a ``.py`` extension. A plain dotted string like
+    ``"my_package.my_module"`` has neither.
+    """
+    return (
+        os.sep in module
+        or (os.altsep is not None and os.altsep in module)
+        or "/" in module
+        or module.endswith(".py")
+    )
+
+
+def _resolve_code_module_path(module: str) -> str:
+    """
+    Resolve a :class:`CodeDependencyNode` ``module`` value (a path to a python file, or
+    an import-like string) to an absolute file path.
+    """
+    if _looks_like_code_file_path(module):
+        # A path to a python file, relative to the current working directory
+        # (or already absolute).
+        return os.path.abspath(os.path.join(os.getcwd(), module))
+    # A dotted Python import string (e.g. "my_package.my_module"): resolve it through
+    # the regular import machinery, so it is found regardless of the current working
+    # directory. This is essential for modules that live inside an installed package,
+    # where guessing a path relative to the working directory generally doesn't work.
+    try:
+        spec = importlib.util.find_spec(module)
+    except (ImportError, ValueError):
+        spec = None
+    if spec is not None and spec.origin is not None:
+        return spec.origin
+    # Not importable either: fall back to a relative-path guess.
+    return os.path.abspath(os.path.join(os.getcwd(), module.replace(".", os.sep) + ".py"))
+
+
 @config.node
 class CodeDependencyNode(FileDependencyNode, classmap_entry="code"):
     """
@@ -428,12 +467,7 @@ class CodeDependencyNode(FileDependencyNode, classmap_entry="code"):
             file_store = self.scaffold.files
         else:
             file_store = None
-        if os.path.isfile(self.module):
-            # Convert potential relative path to absolute path
-            module_file = os.path.abspath(os.path.join(os.getcwd(), self.module))
-        else:
-            # Module like string converted to a path string relative to current folder
-            module_file = "./" + self.module.replace(".", os.sep) + ".py"
+        module_file = _resolve_code_module_path(self.module)
         return FileDependency(module_file, file_store=file_store)
 
     def __init__(self, module=None, **kwargs):

--- a/packages/bsb-core/tests/test_configuration.py
+++ b/packages/bsb-core/tests/test_configuration.py
@@ -2,7 +2,9 @@ import importlib.metadata
 import inspect
 import json
 import os.path
+import pathlib
 import sys
+import tempfile
 import unittest
 
 import numpy as np
@@ -1498,6 +1500,39 @@ class TestTypes(unittest.TestCase):
             _parent=TestRoot(),
         )
         self.assertEqual(b.c.load_object(), module.tree)
+
+    def test_code_dependency_node_installed_module(self):
+        # Regression test: a dotted import string pointing to a module of an
+        # installed package (i.e. not located relative to the current working
+        # directory) must be resolved through the import machinery, instead of
+        # being naively guessed as a path relative to `cwd`.
+        @config.node
+        class Test:
+            c = config.attr(type=CodeDependencyNode)
+
+        import bsb_test.configs as installed_module
+
+        expected_path = os.path.abspath(installed_module.__file__)
+        expected_uri = pathlib.Path(expected_path).as_uri()
+        old_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.chdir(tmpdir)
+            try:
+                b = Test(
+                    c="bsb_test.configs",
+                    _parent=TestRoot(),
+                )
+                self.assertEqual(
+                    b.c.file.uri,
+                    expected_uri,
+                    "module-like string should resolve through the import "
+                    "machinery, not a path guess relative to cwd",
+                )
+                loaded = b.c.load_object()
+                self.assertEqual(os.path.abspath(loaded.__file__), expected_path)
+                self.assertTrue(hasattr(loaded, "get_test_config_module"))
+            finally:
+                os.chdir(old_cwd)
 
 
 @config.dynamic(


### PR DESCRIPTION
## Describe the work done
Change code dependency components logic to interpret paths provided by user: 
If the path is file path and if it points to a real file is kept as is, 
Else if, the path is a dotted path then use `importlib` to check the module
Else, try to convert the dotted path to a file path.

## Tasks

* [x] Added tests


<!-- readthedocs-preview bsb-core start -->
----
📚 Documentation preview 📚: https://bsb-core--255.org.readthedocs.build/en/255/

<!-- readthedocs-preview bsb-core end -->

<!-- readthedocs-preview bsb start -->
----
📚 Documentation preview 📚: https://bsb--255.org.readthedocs.build/en/255/

<!-- readthedocs-preview bsb end -->

<!-- readthedocs-preview bsb-otel start -->
----
📚 Documentation preview 📚: https://bsb-otel--255.org.readthedocs.build/en/255/

<!-- readthedocs-preview bsb-otel end -->

<!-- readthedocs-preview bsb-neuron start -->
----
📚 Documentation preview 📚: https://bsb-neuron--255.org.readthedocs.build/en/255/

<!-- readthedocs-preview bsb-neuron end -->

<!-- readthedocs-preview bsb-hdf5 start -->
----
📚 Documentation preview 📚: https://bsb-hdf5--255.org.readthedocs.build/en/255/

<!-- readthedocs-preview bsb-hdf5 end -->